### PR TITLE
FlatLineTest cpp functions now using Eigen library, >30% speed up

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -54,7 +54,8 @@ LinkingTo:
     RcppArmadillo,
     Rcpp,
     cpp11,
-    RcppThread
+    RcppThread, 
+    RcppEigen
 URL: https://github.com/drostlab/myTAI
 BugReports: https://github.com/drostlab/myTAI/issues
 RoxygenNote: 7.2.3

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -4,6 +4,9 @@
 #include <RcppArmadillo.h>
 #include <RcppThread.h>
 #include <Rcpp.h>
+#include <RcppEigen.h>
+#include <Eigen/Dense>
+// [[Rcpp::depends(RcppEigen)]]
 
 using namespace Rcpp;
 
@@ -13,25 +16,26 @@ Rcpp::Rostream<false>& Rcpp::Rcerr = Rcpp::Rcpp_cerr_get();
 #endif
 
 // cpp_TAI
-NumericVector cpp_TAI(const NumericMatrix& ExpressionSet, const NumericVector& Phylostratum);
+Eigen::VectorXd cpp_TAI(const Eigen::MatrixXd& ExpressionSet, const Eigen::VectorXd& Phylostratum);
 RcppExport SEXP _myTAI_cpp_TAI(SEXP ExpressionSetSEXP, SEXP PhylostratumSEXP) {
-BEGIN_RCPP
-    Rcpp::RObject rcpp_result_gen;
-    Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< const NumericMatrix& >::type ExpressionSet(ExpressionSetSEXP);
-    Rcpp::traits::input_parameter< const NumericVector& >::type Phylostratum(PhylostratumSEXP);
-    rcpp_result_gen = Rcpp::wrap(cpp_TAI(ExpressionSet, Phylostratum));
-    return rcpp_result_gen;
-END_RCPP
+  BEGIN_RCPP
+  Rcpp::RObject rcpp_result_gen;
+  Rcpp::RNGScope rcpp_rngScope_gen;
+  Rcpp::traits::input_parameter< const Eigen::MatrixXd& >::type ExpressionSet(ExpressionSetSEXP);
+  Rcpp::traits::input_parameter< const Eigen::VectorXd& >::type Phylostratum(PhylostratumSEXP);
+  rcpp_result_gen = Rcpp::wrap(cpp_TAI(ExpressionSet, Phylostratum));
+  return rcpp_result_gen;
+  END_RCPP
 }
+
 // cpp_bootMatrix
-NumericMatrix cpp_bootMatrix(const NumericMatrix& ExpressionMatrix, const NumericVector& AgeVector, const int& permutations);
+Eigen::MatrixXd cpp_bootMatrix(const Eigen::MatrixXd& ExpressionMatrix, const Eigen::VectorXd& AgeVector, const int& permutations);
 RcppExport SEXP _myTAI_cpp_bootMatrix(SEXP ExpressionMatrixSEXP, SEXP AgeVectorSEXP, SEXP permutationsSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< const NumericMatrix& >::type ExpressionMatrix(ExpressionMatrixSEXP);
-    Rcpp::traits::input_parameter< const NumericVector& >::type AgeVector(AgeVectorSEXP);
+    Rcpp::traits::input_parameter< const Eigen::MatrixXd& >::type ExpressionMatrix(ExpressionMatrixSEXP);
+    Rcpp::traits::input_parameter< const Eigen::VectorXd& >::type AgeVector(AgeVectorSEXP);
     Rcpp::traits::input_parameter< const int& >::type permutations(permutationsSEXP);
     rcpp_result_gen = Rcpp::wrap(cpp_bootMatrix(ExpressionMatrix, AgeVector, permutations));
     return rcpp_result_gen;

--- a/src/cpp11.cpp
+++ b/src/cpp11.cpp
@@ -18,17 +18,17 @@ extern "C" SEXP _myTAI_fun() {
 
 extern "C" {
 /* .Call calls */
-extern SEXP _myTAI_cpp_TAI(SEXP, SEXP);
-extern SEXP _myTAI_cpp_bootMatrix(SEXP, SEXP, SEXP);
-extern SEXP _myTAI_cpp_geom_mean(SEXP);
-extern SEXP _myTAI_cpp_harmonic_mean(SEXP);
-extern SEXP _myTAI_cpp_omitMatrix(SEXP, SEXP);
-extern SEXP _myTAI_cpp_pMatrix(SEXP, SEXP);
-extern SEXP _myTAI_cpp_std_error(SEXP);
-extern SEXP _myTAI_rcpp_boottei_parallel(SEXP, SEXP, SEXP, SEXP);
-extern SEXP _myTAI_rcpp_pMatrix_parallel(SEXP, SEXP, SEXP);
-extern SEXP _myTAI_rcpp_pStrata_parallel(SEXP, SEXP, SEXP, SEXP);
-extern SEXP _myTAI_rcpp_tei_parallel(SEXP, SEXP, SEXP);
+extern SEXP _myTAI_cpp_TAI(void *, void *);
+extern SEXP _myTAI_cpp_bootMatrix(void *, void *, void *);
+extern SEXP _myTAI_cpp_geom_mean(void *);
+extern SEXP _myTAI_cpp_harmonic_mean(void *);
+extern SEXP _myTAI_cpp_omitMatrix(void *, void *);
+extern SEXP _myTAI_cpp_pMatrix(void *, void *);
+extern SEXP _myTAI_cpp_std_error(void *);
+extern SEXP _myTAI_rcpp_boottei_parallel(void *, void *, void *, void *);
+extern SEXP _myTAI_rcpp_pMatrix_parallel(void *, void *, void *);
+extern SEXP _myTAI_rcpp_pStrata_parallel(void *, void *, void *, void *);
+extern SEXP _myTAI_rcpp_tei_parallel(void *, void *, void *);
 
 static const R_CallMethodDef CallEntries[] = {
     {"_myTAI_cpp_TAI",               (DL_FUNC) &_myTAI_cpp_TAI,               2},

--- a/src/rcpp_funcs.cpp
+++ b/src/rcpp_funcs.cpp
@@ -54,7 +54,7 @@ NumericVector permut(const NumericVector& a)
   // clone a into b to leave a alone
   NumericVector b = clone(a);
   
-  std::shuffle(b.begin(), b.end(), urng);
+  std::shuffle(b.begin(), b.end(), lcg);
   
   return b;
 }

--- a/src/rcpp_funcs.cpp
+++ b/src/rcpp_funcs.cpp
@@ -29,7 +29,7 @@ int randWrapper(const int& n)
 
 // Initilizing the random number generator outside of the function
 std::random_device rng;
-std::mt19937 urng(rng());
+std::mt19937_64 urng(rng());
 std::linear_congruential_engine<unsigned int, 48271, 1, 65536> lcg(rng());
 
 Eigen::MatrixXd permut_mat(const Eigen::VectorXd& a,const int& permutations) {

--- a/src/rcpp_funcs.cpp
+++ b/src/rcpp_funcs.cpp
@@ -5,8 +5,11 @@
 #include <random>
 #include <RcppThread.h>
 #include <string.h>
+#include <RcppEigen.h>
+#include <Eigen/Dense>
 // [[Rcpp::depends(RcppThread)]]
 // [[Rcpp::depends(RcppArmadillo)]]
+// [[Rcpp::depends(RcppEigen)]]
 // [[Rcpp::plugins(cpp11)]]
 
 using namespace Rcpp;
@@ -27,90 +30,53 @@ int randWrapper(const int& n)
 // Initilizing the random number generator outside of the function
 std::random_device rng;
 std::mt19937 urng(rng());
+std::linear_congruential_engine<unsigned int, 48271, 1, 65536> lcg(rng());
+
+Eigen::MatrixXd permut_mat(const Eigen::VectorXd& a,const int& permutations) {
+  // already added by sourceCpp(), but needed standalone
+  Eigen::MatrixXd permutedMat(permutations, a.size());
+  Eigen::VectorXd shuffledVec = a;
+  
+  
+  for (int i = 0; i < permutations; i++) {
+    std::shuffle(shuffledVec.data(), shuffledVec.data() + shuffledVec.size(), lcg);
+    permutedMat.row(i) = shuffledVec.transpose();
+  }
+  return permutedMat;
+}
 
 NumericVector permut(const NumericVector& a)
 {
-        
-        // already added by sourceCpp(), but needed standalone
-        // RNGScope scope;             
-        
-        // clone a into b to leave a alone
-        NumericVector b = clone(a);
-        
-        std::shuffle(b.begin(), b.end(), urng);
-        
-        return b;
-}
-
-
-// @export
-// [[Rcpp::export]]
-NumericVector cpp_TAI(const NumericMatrix& ExpressionSet, const NumericVector& Phylostratum)
-{
-        
-        int nCols = ExpressionSet.ncol();
-        int nRows = ExpressionSet.nrow();
-        NumericVector results(nCols);
-        for(int stage = 0; stage < nCols; stage++) {
-                double numerator = 0, divisor = 0;
-                for(int gene = 0; gene < nRows; gene++) {
-                        numerator+= (double) Phylostratum[gene] * ExpressionSet(gene, stage);
-                        divisor  += ExpressionSet(gene, stage);
-                }
-                
-                results[stage] = numerator/divisor;
-        }
-        
-        return results;
-        
+  
+  // already added by sourceCpp(), but needed standalone
+  // RNGScope scope;             
+  
+  // clone a into b to leave a alone
+  NumericVector b = clone(a);
+  
+  std::shuffle(b.begin(), b.end(), urng);
+  
+  return b;
 }
 
 // @export
 // [[Rcpp::export]]
-NumericMatrix cpp_bootMatrix(const NumericMatrix& ExpressionMatrix, const NumericVector& AgeVector, const int& permutations)
+Eigen::VectorXd cpp_TAI(const Eigen::MatrixXd& ExpressionMatrix, const Eigen::VectorXd& Phylostratum) {
+  
+  Eigen::VectorXd Divisor = ExpressionMatrix.colwise().sum();
+  Eigen::MatrixXd fMatrix = ExpressionMatrix.array().rowwise() / Divisor.transpose().array();
+  Eigen::VectorXd total = Phylostratum.transpose() * fMatrix;
+  
+  return total;
+}
+// @export
+// [[Rcpp::export]]
+Eigen::MatrixXd cpp_bootMatrix(const Eigen::MatrixXd& ExpressionMatrix, const Eigen::VectorXd& AgeVector, const int& permutations) 
 {
-        
-        int nCols = ExpressionMatrix.ncol();
-        int nRows = ExpressionMatrix.nrow();
-        NumericVector Divisor(nCols);
-        NumericMatrix fMatrix(nRows,nCols);
-        NumericVector sampledVector(AgeVector.size());
-        NumericVector AgeValues(nCols);
-        NumericMatrix bootM(permutations,nCols);
-        
-        for(int j = 0; j < nCols; j++){
-                double div = 0;
-                for(int i = 0; i < nRows; i++){
-                        div += ExpressionMatrix(i,j);    
-                }
-                
-                Divisor[j] = div;
-                
-        }
-        
-        for(int l = 0; l < nCols; l++){
-                for(int k = 0; k < nRows; k++){
-                        fMatrix(k,l) = ExpressionMatrix(k,l)/Divisor[l];    
-                }
-        }
-        
-        
-        for(int n = 0; n < permutations; n++){
-                
-                //sampledVector = Rcpp::RcppArmadillo::sample(AgeVector, AgeVector.size(), FALSE);
-                sampledVector = permut(AgeVector);
-                
-                for(int b = 0; b < nCols; b++){
-                        double total = 0;
-                        for(int a = 0; a < nRows; a++){
-                                total += (sampledVector[a] * fMatrix(a,b));    
-                        }
-                        
-                        bootM(n,b) = total;
-                        
-                }
-        }
-        
+        Eigen::VectorXd Divisor = ExpressionMatrix.colwise().sum();
+        Eigen::MatrixXd fMatrix = ExpressionMatrix.array().rowwise() / Divisor.transpose().array();
+        Eigen::MatrixXd permMatrix = permut_mat(AgeVector,permutations);
+        Eigen::MatrixXd bootM = permMatrix * fMatrix;
         return bootM;
 }
 


### PR DESCRIPTION
Implemented FlatLineTest cpp functions using Eigen library. Now it looks much more clean and elegant. Didn't benchmark the speed yet, but might not be a very significant speed up, since most of the time is perhaps taken up by generating the permutations. 

Will rewrite the other cpp functions to Eigen soon.

Looked into generators included in std and made the permutation functions use linear congruential generator, instead of mersenne as a generator. Now the FlatLineTest is >30% faster. 

Also replaced mersenne with mersenne 64, which is way faster (still slower than lcg) in case we decide on using mersenne at the end.