### PR TITLE
`PlotSignatureTransformed()`: Removed `vst` from the default transforms parameter

### DIFF
--- a/R/PlotSignatureTransformed.R
+++ b/R/PlotSignatureTransformed.R
@@ -85,8 +85,7 @@
 #' # Flat line test
 #' PlotSignatureTransformed(ExpressionSet = PhyloExpressionSetExample,
 #'                     TestStatistic = "FlatLineTest",
-#'                     transforms = c("none", "log2", "sqrt", "vst", "rank", "squared"),
-#'                     modules = list(early = 1:2, mid = 3:5, late = 6:7))
+#'                     transforms = c("none", "log2", "sqrt", "rank", "squared"))
 #'
 #' # Reductive hourglass test
 #' PlotSignatureTransformed(ExpressionSet = PhyloExpressionSetExample,
@@ -106,7 +105,7 @@ PlotSignatureTransformed <-
   function(ExpressionSet,
            measure            = "TAI",
            TestStatistic      = "FlatLineTest",
-           transforms         = c("none", "log2", "sqrt", "vst", "rank", "squared"),
+           transforms         = c("none", "sqrt", "log2", "rank", "squared"),
            modules            = NULL,
            permutations       = 1000,
            pseudocount        = 1,

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Please cite the following paper when using `myTAI` for your own research. This w
 
 **Mac:**
 ```bash
-brew install llvm libomp lomp
+brew install llvm libomp
 cd /usr/local/lib
 ln -s /usr/local/opt/libomp/lib/libomp.dylib ./libomp.dylib
 ```

--- a/man/PlotSignatureTransformed.Rd
+++ b/man/PlotSignatureTransformed.Rd
@@ -8,7 +8,7 @@ PlotSignatureTransformed(
   ExpressionSet,
   measure = "TAI",
   TestStatistic = "FlatLineTest",
-  transforms = c("none", "log2", "sqrt", "vst", "rank", "squared"),
+  transforms = c("none", "sqrt", "log2", "rank", "squared"),
   modules = NULL,
   permutations = 1000,
   pseudocount = 1,


### PR DESCRIPTION
Dear Hajk,

I think PlotSignatureTransformed() should run with the default installation of `myTAI` without `DESeq2`.

However, `PlotSignatureTransformed()` had `vst` as one of the transformations as a default, i.e. `transforms = c("none", "log2", "sqrt", "vst", "rank", "squared")`. Since, `vst` is from the DESeq2 package and in case DESeq2 is not installed or doesn't satisfy `DESeq2 (>= 1.29.15)`, then the function will not work.

The default parameters are now.

```r
PlotSignatureTransformed <-
  function(ExpressionSet,
           measure            = "TAI",
           TestStatistic      = "FlatLineTest",
           transforms         = c("none", "sqrt", "log2", "rank", "squared"),
           modules            = NULL,
           permutations       = 1000,
           pseudocount        = 1,
           p.value            = TRUE,
           shaded.area        = FALSE,
           xlab               = "Ontogeny",
           ylab               = "Transcriptome Index",
           main               = "",
           lwd                = 4,
           alpha              = 0.1,
           y.ticks            = 3)
```

However, the issue of `ks.test.default` warning messages for `TestStatistic = "FlatLineTest"` remains.

Best,
Sodai